### PR TITLE
Fix bugs caused by lack of diode tdms

### DIFF
--- a/funcs/post_processing.py
+++ b/funcs/post_processing.py
@@ -15,7 +15,6 @@ from . import diodes, schlieren, uncertainty
 from ._dev import d_drive
 from .diodes import find_diode_data, calculate_velocity
 
-
 _DIR = os.path.split(__file__)[0]
 
 
@@ -212,6 +211,7 @@ class _ProcessNewData:
 
         else:
             for idx, test_time_row in df_tests.iterrows():
+                # noinspection PyTypeChecker
                 _, row_results = cls._process_single_test(
                     idx,
                     df_nominal,
@@ -424,9 +424,7 @@ class _ProcessNewData:
             # do bg subtraction
             date = os.path.split(
                 os.path.dirname(
-                    os.path.dirname(
-                        test_time_row["diodes"]
-                    )
+                    test_time_row["schlieren"]
                 )
             )[1]
             out["schlieren"] = {


### PR DESCRIPTION
Lack of diode tdms leads to NaN values being passed in place of a string
for diode data location, which caused a mess of issues. These have been
cleaned up, and velocity calculation now returns NaN+/-NaN on a failed
calculation, which it probably should have done in the first place
instead of 0+/-0.